### PR TITLE
Retry IndexNow key verification after deploy

### DIFF
--- a/web/scripts/submit-indexnow.mjs
+++ b/web/scripts/submit-indexnow.mjs
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 const SITE_URL = "https://codexpet.top";
 const KEY = "d687eb8cfb15d89e9bf7c9c00f0a8c20";
 const REQUEST_TIMEOUT_MS = 15_000;
+const KEY_VERIFY_ATTEMPTS = 12;
+const KEY_VERIFY_DELAY_MS = 5_000;
 const argumentsList = process.argv.slice(2);
 const dryRun = argumentsList.includes("--dry-run");
 const sitemapPath =
@@ -12,6 +14,22 @@ const sitemap = await readFile(sitemapPath, "utf8");
 const urlList = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
   (match) => match[1],
 );
+
+async function waitForPublishedKey(keyLocation) {
+  for (let attempt = 1; attempt <= KEY_VERIFY_ATTEMPTS; attempt += 1) {
+    const response = await fetch(`${keyLocation}?verify=${Date.now()}`, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const publishedKey = response.ok ? (await response.text()).trim() : "";
+    if (publishedKey === KEY) return;
+    if (attempt < KEY_VERIFY_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, KEY_VERIFY_DELAY_MS));
+    }
+  }
+  throw new Error(
+    `IndexNow key verification failed at ${keyLocation} after ${KEY_VERIFY_ATTEMPTS} attempts.`,
+  );
+}
 
 if (urlList.length === 0 || urlList.length > 10_000) {
   throw new Error(`Expected 1-10000 sitemap URLs, found ${urlList.length}.`);
@@ -24,15 +42,7 @@ if (dryRun) {
   console.log(`Validated ${urlList.length} canonical URLs for IndexNow.`);
 } else {
   const keyLocation = `${SITE_URL}/${KEY}.txt`;
-  const keyResponse = await fetch(`${keyLocation}?verify=${Date.now()}`, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
-  const publishedKey = keyResponse.ok ? (await keyResponse.text()).trim() : "";
-  if (publishedKey !== KEY) {
-    throw new Error(
-      `IndexNow key verification failed at ${keyLocation}: HTTP ${keyResponse.status}.`,
-    );
-  }
+  await waitForPublishedKey(keyLocation);
 
   const response = await fetch("https://api.indexnow.org/indexnow", {
     method: "POST",


### PR DESCRIPTION
## Summary
- retry the public IndexNow key check for up to 60 seconds after a Cloudflare deployment
- avoid dropping automatic URL notifications during CDN propagation

## Verification
- `node web/scripts/submit-indexnow.mjs web/out/sitemap.xml --dry-run`
- web `npm run lint`
- live submission accepted 179 canonical URLs after the new key became available