### PR TITLE
fix: harden community rankings

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -84,7 +84,7 @@ npx wrangler pages deploy out --project-name=awesome-codex-pet
 - **Community pages**: Static contributor profiles and pet, contributor, and collection rankings are generated at build time
 - **Hosting**: Cloudflare Pages (global CDN, free tier)
 - **Stats reads**: deployment-time `public/stats.json`, served as a free Pages static asset; rankings do not poll the Worker
-- **Stats writes**: a separate Worker at `https://api.codexpet.top` records explicit installs, IP-limited likes, and one weekly pet or collection vote per privacy-scoped visitor. Ordinary page views never invoke it. See `worker/README.md`.
+- **Stats writes**: a separate Worker at `https://api.codexpet.top` records explicit installs, IP-limited likes, and one pet vote plus one collection vote per privacy-scoped visitor each week. Ordinary page views never invoke it. See `worker/README.md`.
 - **Preview delivery**: cards load a static thumbnail first and fetch animation on hover or keyboard focus; detail pages keep the complete action set
 - **Caching**: Next.js hashed assets are immutable, preview assets use a seven-day browser cache, and the deployment-time statistics snapshot uses a ten-minute cache
 

--- a/web/app/contributors/[slug]/page.tsx
+++ b/web/app/contributors/[slug]/page.tsx
@@ -74,7 +74,9 @@ export default async function ContributorPage({
     <>
       <ContributorPageContent contributor={contributor} pets={pets} />
       <script
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replaceAll("<", "\\u003c"),
+        }}
         type="application/ld+json"
       />
     </>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,12 +7,15 @@ import { CommunityPulse } from "@/components/community-pulse";
 import { getCollections } from "@/lib/collection-catalog";
 import { toCollectionCardData } from "@/lib/collections";
 import {
+  getCommunityPulseData,
+  getLeaderboardData,
+} from "@/lib/leaderboards";
+import {
   getAllPets,
   getCategories,
   toGalleryPet,
 } from "@/lib/pets";
 import { getTrendingPets } from "@/lib/ranking";
-import { getLeaderboardData } from "@/lib/leaderboards";
 import { siteConfig } from "@/lib/site";
 
 export const metadata: Metadata = {
@@ -59,6 +62,7 @@ export default function HomePage() {
   const collections = getCollections(pets).map(toCollectionCardData);
   const featured = getTrendingPets(pets, 6).map(toGalleryPet);
   const leaderboard = getLeaderboardData(pets);
+  const communityPulse = getCommunityPulseData(leaderboard);
 
   const pageJsonLd = {
     "@context": "https://schema.org",
@@ -144,7 +148,7 @@ export default function HomePage() {
       />
       <section className="px-6 py-16">
         <div className="mx-auto max-w-[1720px]">
-          <CommunityPulse data={leaderboard} />
+          <CommunityPulse data={communityPulse} />
           <FeaturedCollections collections={collections} />
           <PetGallery pets={galleryPets} categories={categories} />
         </div>

--- a/web/app/rankings/page.tsx
+++ b/web/app/rankings/page.tsx
@@ -75,7 +75,9 @@ export default function RankingsPage() {
     <>
       <RankingsPageContent data={data} />
       <script
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replaceAll("<", "\\u003c"),
+        }}
         type="application/ld+json"
       />
     </>

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -8,6 +8,7 @@ import { siteConfig } from "@/lib/site";
 export const dynamic = "force-static";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const pets = getAllPets();
   const staticEntries: MetadataRoute.Sitemap = [
     {
       url: `${siteConfig.url}/collections`,
@@ -55,17 +56,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
   ];
-  const petEntries = getAllPets().map((pet) => ({
+  const petEntries = pets.map((pet) => ({
     url: `${siteConfig.url}/pets/${pet.slug}`,
     changeFrequency: "monthly" as const,
     priority: 0.8,
   }));
-  const collectionEntries = getCollectionSlugs(getAllPets()).map((slug) => ({
+  const collectionEntries = getCollectionSlugs(pets).map((slug) => ({
     url: `${siteConfig.url}/collections/${slug}`,
     changeFrequency: "weekly" as const,
     priority: 0.75,
   }));
-  const contributorEntries = getContributorSlugs(getAllPets()).map((slug) => ({
+  const contributorEntries = getContributorSlugs(pets).map((slug) => ({
     url: `${siteConfig.url}/contributors/${slug}`,
     changeFrequency: "weekly" as const,
     priority: 0.65,

--- a/web/components/community-pulse.tsx
+++ b/web/components/community-pulse.tsx
@@ -4,16 +4,10 @@ import Link from "next/link";
 
 import { useLocale } from "@/components/locale-provider";
 import { getLocalizedPetName } from "@/lib/codex-links";
-import type { LeaderboardData } from "@/lib/leaderboards";
+import type { CommunityPulseData } from "@/lib/leaderboards";
 
-export function CommunityPulse({ data }: { data: LeaderboardData }) {
+export function CommunityPulse({ data }: { data: CommunityPulseData }) {
   const { locale, t } = useLocale();
-  const pets = [...data.pets]
-    .sort((a, b) => b.weeklyScore - a.weeklyScore)
-    .slice(0, 3);
-  const contributors = [...data.contributors]
-    .sort((a, b) => b.weeklyScore - a.weeklyScore)
-    .slice(0, 3);
 
   return (
     <section
@@ -40,7 +34,7 @@ export function CommunityPulse({ data }: { data: LeaderboardData }) {
           </Link>
         </div>
         <ol className="divide-y divide-border">
-          {pets.map((entry, index) => (
+          {data.pets.map((entry, index) => (
             <li
               className="grid grid-cols-[1.5rem_2.5rem_minmax(0,1fr)_auto] items-center gap-2 py-2"
               key={entry.pet.slug}
@@ -60,13 +54,13 @@ export function CommunityPulse({ data }: { data: LeaderboardData }) {
                 {getLocalizedPetName(entry.pet, locale)}
               </Link>
               <span className="font-mono text-xs tabular-nums text-muted">
-                {entry.stats.installs7d} / 7d
+                {t("rankingWeeklyInstalls", { count: entry.installs7d })}
               </span>
             </li>
           ))}
         </ol>
         <ol className="divide-y divide-border">
-          {contributors.map((entry, index) => (
+          {data.contributors.map((entry, index) => (
             <li
               className="grid grid-cols-[1.5rem_2.5rem_minmax(0,1fr)_auto] items-center gap-2 py-2"
               key={entry.slug}
@@ -75,11 +69,11 @@ export function CommunityPulse({ data }: { data: LeaderboardData }) {
                 {index + 1}
               </span>
               <div className="flex size-10 items-center justify-center overflow-hidden rounded-full border border-border bg-bg-secondary">
-                {entry.pets[0] ? (
+                {entry.previewImage ? (
                   <img
                     alt=""
                     className="max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                    src={entry.pets[0].previewImage}
+                    src={entry.previewImage}
                   />
                 ) : (
                   <span className="text-xs font-semibold text-muted">

--- a/web/components/contributor-page-content.tsx
+++ b/web/components/contributor-page-content.tsx
@@ -50,7 +50,7 @@ export function ContributorPageContent({
       <header className="mt-8 grid gap-8 border-b border-border pb-10 lg:grid-cols-[1fr_auto] lg:items-end">
         <div>
           <p className="mb-3 text-xs font-semibold uppercase text-accent">
-            {t("contributorCollection")}
+            {t("contributorRoleLabel")}
           </p>
           <h1 className="text-4xl font-semibold text-text sm:text-5xl">
             {contributor.name}

--- a/web/components/rankings-page-content.tsx
+++ b/web/components/rankings-page-content.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import {
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { useLocale } from "@/components/locale-provider";
 import { getLocalizedPetName } from "@/lib/codex-links";
@@ -39,9 +44,9 @@ function rankClass(rank: number) {
 
 function sortRanked<T extends { weeklyScore: number; allScore: number }>(
   entries: T[],
-  window: RankingWindow,
+  rankingWindow: RankingWindow,
 ) {
-  const key = window === "weekly" ? "weeklyScore" : "allScore";
+  const key = rankingWindow === "weekly" ? "weeklyScore" : "allScore";
   return [...entries].sort((a, b) => b[key] - a[key]);
 }
 
@@ -113,7 +118,8 @@ export function RankingsPageContent({
 }) {
   const { locale, t } = useLocale();
   const [tab, setTab] = useState<RankingTab>("pets");
-  const [window, setWindow] = useState<RankingWindow>("weekly");
+  const [rankingWindow, setRankingWindow] =
+    useState<RankingWindow>("weekly");
   const [selectedVotes, setSelectedVotes] = useState<
     Record<VoteKind, string | null>
   >({
@@ -144,16 +150,16 @@ export function RankingsPageContent({
   }, [data.votePeriod.id]);
 
   const rankedPets = useMemo(
-    () => sortRanked(data.pets, window).slice(0, rankingLimit),
-    [data.pets, window],
+    () => sortRanked(data.pets, rankingWindow).slice(0, rankingLimit),
+    [data.pets, rankingWindow],
   );
   const rankedContributors = useMemo(
-    () => sortRanked(data.contributors, window).slice(0, rankingLimit),
-    [data.contributors, window],
+    () => sortRanked(data.contributors, rankingWindow).slice(0, rankingLimit),
+    [data.contributors, rankingWindow],
   );
   const rankedCollections = useMemo(
-    () => sortRanked(data.collections, window).slice(0, rankingLimit),
-    [data.collections, window],
+    () => sortRanked(data.collections, rankingWindow).slice(0, rankingLimit),
+    [data.collections, rankingWindow],
   );
   const hasWeeklyActivity =
     data.pets.some(
@@ -164,6 +170,26 @@ export function RankingsPageContent({
     { value: "contributors", label: t("rankingContributors") },
     { value: "collections", label: t("rankingCollections") },
   ];
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = tabs.findIndex((item) => item.value === tab);
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? tabs.length - 1
+          : event.key === "ArrowRight"
+            ? (currentIndex + 1) % tabs.length
+            : (currentIndex - 1 + tabs.length) % tabs.length;
+    setTab(tabs[nextIndex].value);
+    event.currentTarget
+      .querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      [nextIndex]?.focus();
+  }
 
   async function castVote(kind: VoteKind, slug: string) {
     setVoteError(false);
@@ -245,19 +271,23 @@ export function RankingsPageContent({
           <div
             aria-label={t("rankings")}
             className="grid h-11 grid-cols-3 rounded-lg border border-border bg-bg-secondary p-1"
+            onKeyDown={handleTabKeyDown}
             role="tablist"
           >
             {tabs.map((item) => (
               <button
+                aria-controls="rankings-panel"
                 aria-selected={tab === item.value}
                 className={`min-w-0 rounded-md px-3 text-sm font-medium transition-colors sm:min-w-32 ${
                   tab === item.value
                     ? "bg-bg-elevated text-text shadow-sm"
                     : "text-muted hover:text-text"
                 }`}
+                id={`rankings-tab-${item.value}`}
                 key={item.value}
                 onClick={() => setTab(item.value)}
                 role="tab"
+                tabIndex={tab === item.value ? 0 : -1}
                 type="button"
               >
                 <span className="block truncate">{item.label}</span>
@@ -270,14 +300,14 @@ export function RankingsPageContent({
           >
             {(["weekly", "all"] as const).map((value) => (
               <button
-                aria-pressed={window === value}
+                aria-pressed={rankingWindow === value}
                 className={`rounded-md px-5 text-sm font-medium transition-colors ${
-                  window === value
+                  rankingWindow === value
                     ? "bg-bg-elevated text-text shadow-sm"
                     : "text-muted hover:text-text"
                 }`}
                 key={value}
-                onClick={() => setWindow(value)}
+                onClick={() => setRankingWindow(value)}
                 type="button"
               >
                 {t(value === "weekly" ? "rankingWeekly" : "rankingAllTime")}
@@ -287,7 +317,7 @@ export function RankingsPageContent({
         </div>
       </div>
 
-      {!hasWeeklyActivity && window === "weekly" ? (
+      {!hasWeeklyActivity && rankingWindow === "weekly" ? (
         <p className="border-b border-border py-5 text-sm text-muted">
           {t("rankingNoActivity")}
         </p>
@@ -298,14 +328,19 @@ export function RankingsPageContent({
         </p>
       ) : null}
 
-      <section className="mt-8" role="tabpanel">
+      <section
+        aria-labelledby={`rankings-tab-${tab}`}
+        className="mt-8"
+        id="rankings-panel"
+        role="tabpanel"
+      >
         {tab === "pets" ? (
           <PetRanking
             entries={rankedPets}
             locale={locale}
             pendingVote={pendingVote}
             selectedVote={selectedVotes.pet}
-            showVote={window === "weekly"}
+            showVote={rankingWindow === "weekly"}
             votes={petVotes}
             onVote={(slug) => void castVote("pet", slug)}
           />
@@ -313,8 +348,7 @@ export function RankingsPageContent({
         {tab === "contributors" ? (
           <ContributorRanking
             entries={rankedContributors}
-            locale={locale}
-            window={window}
+            rankingWindow={rankingWindow}
           />
         ) : null}
         {tab === "collections" ? (
@@ -323,7 +357,7 @@ export function RankingsPageContent({
             locale={locale}
             pendingVote={pendingVote}
             selectedVote={selectedVotes.collection}
-            showVote={window === "weekly"}
+            showVote={rankingWindow === "weekly"}
             votes={collectionVotes}
             onVote={(slug) => void castVote("collection", slug)}
           />
@@ -432,12 +466,10 @@ function PetRanking({
 
 function ContributorRanking({
   entries,
-  locale,
-  window,
+  rankingWindow,
 }: {
   entries: RankedContributor[];
-  locale: "en" | "zh";
-  window: RankingWindow;
+  rankingWindow: RankingWindow;
 }) {
   const { t } = useLocale();
   return (
@@ -483,7 +515,11 @@ function ContributorRanking({
             <div className="hidden sm:block">
               <Metric
                 label={t("rankingInstalls")}
-                value={window === "weekly" ? entry.installs7d : entry.installs}
+                value={
+                  rankingWindow === "weekly"
+                    ? entry.installs7d
+                    : entry.installs
+                }
               />
             </div>
             <div className="hidden md:block">
@@ -491,11 +527,15 @@ function ContributorRanking({
             </div>
             <Metric
               label={
-                window === "weekly"
+                rankingWindow === "weekly"
                   ? t("rankingVotes")
                   : t("rankingPets")
               }
-              value={window === "weekly" ? entry.weeklyVotes : entry.petCount}
+              value={
+                rankingWindow === "weekly"
+                  ? entry.weeklyVotes
+                  : entry.petCount
+              }
             />
           </li>
         );

--- a/web/components/rankings-page-content.tsx
+++ b/web/components/rankings-page-content.tsx
@@ -276,7 +276,7 @@ export function RankingsPageContent({
           >
             {tabs.map((item) => (
               <button
-                aria-controls="rankings-panel"
+                aria-controls={`rankings-panel-${item.value}`}
                 aria-selected={tab === item.value}
                 className={`min-w-0 rounded-md px-3 text-sm font-medium transition-colors sm:min-w-32 ${
                   tab === item.value
@@ -329,9 +329,10 @@ export function RankingsPageContent({
       ) : null}
 
       <section
-        aria-labelledby={`rankings-tab-${tab}`}
+        aria-labelledby="rankings-tab-pets"
         className="mt-8"
-        id="rankings-panel"
+        hidden={tab !== "pets"}
+        id="rankings-panel-pets"
         role="tabpanel"
       >
         {tab === "pets" ? (
@@ -345,12 +346,28 @@ export function RankingsPageContent({
             onVote={(slug) => void castVote("pet", slug)}
           />
         ) : null}
+      </section>
+      <section
+        aria-labelledby="rankings-tab-contributors"
+        className="mt-8"
+        hidden={tab !== "contributors"}
+        id="rankings-panel-contributors"
+        role="tabpanel"
+      >
         {tab === "contributors" ? (
           <ContributorRanking
             entries={rankedContributors}
             rankingWindow={rankingWindow}
           />
         ) : null}
+      </section>
+      <section
+        aria-labelledby="rankings-tab-collections"
+        className="mt-8"
+        hidden={tab !== "collections"}
+        id="rankings-panel-collections"
+        role="tabpanel"
+      >
         {tab === "collections" ? (
           <CollectionRanking
             entries={rankedCollections}

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -99,6 +99,7 @@ export const translations = {
     rankingInstalls: "Installs",
     rankingLikes: "Likes",
     rankingVotes: "Votes",
+    rankingWeeklyInstalls: "{count} / 7d",
     rankingPetCount: "{count} pets",
     rankingSnapshot: "Statistics snapshot",
     rankingEnds: "Voting ends {date}",
@@ -107,7 +108,7 @@ export const translations = {
     rankingNoActivity:
       "The weekly board is just getting started. Cast a vote to help shape the first results.",
     contributorBack: "Back to rankings",
-    contributorCollection: "Community creator",
+    contributorRoleLabel: "Community creator",
     contributorPageTitle: "Pets by {name}",
     contributorPageSubtitle:
       "{name} has {count} accepted pets in the Awesome Codex Pet community.",
@@ -502,6 +503,7 @@ export const translations = {
     rankingInstalls: "安装",
     rankingLikes: "点赞",
     rankingVotes: "票",
+    rankingWeeklyInstalls: "近 7 日 {count}",
     rankingPetCount: "{count} 只宠物",
     rankingSnapshot: "部署统计快照",
     rankingEnds: "本期投票于 {date} 结束",
@@ -509,7 +511,7 @@ export const translations = {
       "近期热度由近 7 日安装和每周投票共同决定。贡献者只计算表现最好的作品，系列使用限制数量后的平均分，避免单纯靠作品数量霸榜。",
     rankingNoActivity: "本周榜刚刚开始，投出一票来决定第一批排名。",
     contributorBack: "返回榜单",
-    contributorCollection: "社区创作者",
+    contributorRoleLabel: "社区创作者",
     contributorPageTitle: "{name} 的宠物",
     contributorPageSubtitle:
       "{name} 已在 Awesome Codex Pet 社区收录 {count} 只宠物。",

--- a/web/lib/leaderboards.ts
+++ b/web/lib/leaderboards.ts
@@ -7,7 +7,11 @@ import {
   type CollectionCardData,
 } from "@/lib/collections";
 import { toGalleryPet, type GalleryPet, type Pet } from "@/lib/pets";
-import type { PetStats, VotePeriod } from "@/lib/stats";
+import type { PetStats } from "@/lib/stats";
+import {
+  getUtcVotePeriod,
+  type VotePeriod,
+} from "@/lib/vote-period";
 
 type RawStatsSnapshot = {
   pets?: Record<string, Partial<PetStats>>;
@@ -58,6 +62,22 @@ export type LeaderboardData = {
   votePeriod: VotePeriod;
 };
 
+export type CommunityPulseData = {
+  pets: Array<{
+    pet: Pick<
+      GalleryPet,
+      "slug" | "name" | "localizedNames" | "displayName" | "previewImage"
+    >;
+    installs7d: number;
+  }>;
+  contributors: Array<{
+    slug: string;
+    name: string;
+    petCount: number;
+    previewImage: string | null;
+  }>;
+};
+
 const emptyPetStats = (): PetStats => ({
   installs: 0,
   likes: 0,
@@ -74,20 +94,7 @@ function nonNegative(value: unknown) {
     : 0;
 }
 
-function fallbackVotePeriod(timestamp: number): VotePeriod {
-  const date = new Date(timestamp || Date.now());
-  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
-  date.setUTCDate(date.getUTCDate() - daysSinceMonday);
-  date.setUTCHours(0, 0, 0, 0);
-  const startsAt = date.getTime();
-  return {
-    id: date.toISOString().slice(0, 10),
-    startsAt,
-    endsAt: startsAt + 7 * 24 * 60 * 60 * 1000,
-  };
-}
-
-function readStatsSnapshot() {
+function loadStatsSnapshot() {
   let snapshot: RawStatsSnapshot = {};
   try {
     snapshot = JSON.parse(
@@ -98,7 +105,7 @@ function readStatsSnapshot() {
   }
 
   const generatedAt = nonNegative(snapshot.generatedAt);
-  const fallbackPeriod = fallbackVotePeriod(generatedAt);
+  const fallbackPeriod = getUtcVotePeriod(generatedAt || Date.now());
   const period = snapshot.votePeriod ?? {};
   return {
     pets: snapshot.pets ?? {},
@@ -113,6 +120,13 @@ function readStatsSnapshot() {
       endsAt: nonNegative(period.endsAt) || fallbackPeriod.endsAt,
     },
   };
+}
+
+let statsSnapshotCache: ReturnType<typeof loadStatsSnapshot> | undefined;
+
+function readStatsSnapshot() {
+  statsSnapshotCache ??= loadStatsSnapshot();
+  return statsSnapshotCache;
 }
 
 function petStats(
@@ -146,9 +160,10 @@ function scorePet(stats: PetStats) {
 
 function sortByScore<T extends { weeklyScore: number; allScore: number }>(
   entries: T[],
-  window: RankingWindow,
+  rankingWindow: RankingWindow,
 ) {
-  const score = window === "weekly" ? "weeklyScore" : "allScore";
+  const score =
+    rankingWindow === "weekly" ? "weeklyScore" : "allScore";
   return [...entries].sort((a, b) => b[score] - a[score]);
 }
 
@@ -177,27 +192,33 @@ function buildContributors(rankedPets: RankedPet[]) {
   }
 
   return [...groups.entries()].map(([slug, entries]) => {
-    const representative = entries[0].pet;
-    const topWeekly = sortByScore(entries, "weekly").slice(0, 3);
-    const topAll = sortByScore(entries, "all").slice(0, 3);
-    const contributionBonus = Math.sqrt(entries.length) * 8;
+    const stableEntries = [...entries].sort((a, b) =>
+      a.pet.slug.localeCompare(b.pet.slug),
+    );
+    const representative = stableEntries[0].pet;
+    const topWeekly = sortByScore(stableEntries, "weekly").slice(0, 3);
+    const topAll = sortByScore(stableEntries, "all").slice(0, 3);
+    const contributionBonus = Math.sqrt(stableEntries.length) * 8;
     return {
       slug,
       name: representative.author,
       handle: representative.author_handle || representative.author,
       url: representative.author_url || "",
-      petCount: entries.length,
+      petCount: stableEntries.length,
       pets: topAll.slice(0, 4).map((entry) => entry.pet),
-      installs: entries.reduce(
+      installs: stableEntries.reduce(
         (total, entry) => total + entry.stats.installs,
         0,
       ),
-      installs7d: entries.reduce(
+      installs7d: stableEntries.reduce(
         (total, entry) => total + entry.stats.installs7d,
         0,
       ),
-      likes: entries.reduce((total, entry) => total + entry.stats.likes, 0),
-      weeklyVotes: entries.reduce(
+      likes: stableEntries.reduce(
+        (total, entry) => total + entry.stats.likes,
+        0,
+      ),
+      weeklyVotes: stableEntries.reduce(
         (total, entry) => total + entry.stats.weeklyVotes,
         0,
       ),
@@ -255,15 +276,46 @@ function buildCollections(
   });
 }
 
+let leaderboardCache: LeaderboardData | undefined;
+
 export function getLeaderboardData(pets: Pet[]): LeaderboardData {
+  if (leaderboardCache) return leaderboardCache;
   const snapshot = readStatsSnapshot();
   const rankedPets = buildRankedPets(pets, snapshot);
-  return {
+  leaderboardCache = {
     pets: rankedPets,
     contributors: buildContributors(rankedPets),
     collections: buildCollections(pets, rankedPets, snapshot),
     generatedAt: snapshot.generatedAt,
     votePeriod: snapshot.votePeriod,
+  };
+  return leaderboardCache;
+}
+
+export function getCommunityPulseData(
+  leaderboard: LeaderboardData,
+): CommunityPulseData {
+  return {
+    pets: sortByScore(leaderboard.pets, "weekly")
+      .slice(0, 3)
+      .map((entry) => ({
+        pet: {
+          slug: entry.pet.slug,
+          name: entry.pet.name,
+          localizedNames: entry.pet.localizedNames,
+          displayName: entry.pet.displayName,
+          previewImage: entry.pet.previewImage,
+        },
+        installs7d: entry.stats.installs7d,
+      })),
+    contributors: sortByScore(leaderboard.contributors, "weekly")
+      .slice(0, 3)
+      .map((entry) => ({
+        slug: entry.slug,
+        name: entry.name,
+        petCount: entry.petCount,
+        previewImage: entry.pets[0]?.previewImage ?? null,
+      })),
   };
 }
 
@@ -287,6 +339,6 @@ export function getContributorSlugs(pets: Pet[]) {
 
 export function rankEntries<
   T extends { weeklyScore: number; allScore: number },
->(entries: T[], window: RankingWindow) {
-  return sortByScore(entries, window);
+>(entries: T[], rankingWindow: RankingWindow) {
+  return sortByScore(entries, rankingWindow);
 }

--- a/web/lib/leaderboards.ts
+++ b/web/lib/leaderboards.ts
@@ -9,7 +9,7 @@ import {
 import { toGalleryPet, type GalleryPet, type Pet } from "@/lib/pets";
 import type { PetStats } from "@/lib/stats";
 import {
-  getUtcVotePeriod,
+  normalizeVotePeriod,
   type VotePeriod,
 } from "@/lib/vote-period";
 
@@ -105,20 +105,14 @@ function loadStatsSnapshot() {
   }
 
   const generatedAt = nonNegative(snapshot.generatedAt);
-  const fallbackPeriod = getUtcVotePeriod(generatedAt || Date.now());
-  const period = snapshot.votePeriod ?? {};
   return {
     pets: snapshot.pets ?? {},
     collections: snapshot.collections ?? {},
     generatedAt,
-    votePeriod: {
-      id:
-        typeof period.id === "string" && period.id
-          ? period.id
-          : fallbackPeriod.id,
-      startsAt: nonNegative(period.startsAt) || fallbackPeriod.startsAt,
-      endsAt: nonNegative(period.endsAt) || fallbackPeriod.endsAt,
-    },
+    votePeriod: normalizeVotePeriod(
+      snapshot.votePeriod,
+      generatedAt || Date.now(),
+    ),
   };
 }
 

--- a/web/lib/stats.ts
+++ b/web/lib/stats.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  getUtcVotePeriod,
+  normalizeVotePeriod,
   type VotePeriod,
 } from "@/lib/vote-period";
 
@@ -88,24 +88,17 @@ function normalizeStatsPayload(value: unknown): StatsPayload {
   }
   const rawPeriod = isRecord(value.votePeriod) ? value.votePeriod : {};
   const generatedAt = asNonNegativeNumber(value.generatedAt);
-  const fallbackPeriod = getUtcVotePeriod(generatedAt || Date.now());
+  const votePeriod = normalizeVotePeriod(
+    rawPeriod,
+    generatedAt || Date.now(),
+  );
 
   return {
     pets,
     collections,
     generatedAt,
     windowDays: asNonNegativeNumber(value.windowDays) || 7,
-    votePeriod: {
-      id:
-        typeof rawPeriod.id === "string" && rawPeriod.id
-          ? rawPeriod.id
-          : fallbackPeriod.id,
-      startsAt:
-        asNonNegativeNumber(rawPeriod.startsAt) || fallbackPeriod.startsAt,
-      endsAt:
-        asNonNegativeNumber(rawPeriod.endsAt) ||
-        fallbackPeriod.endsAt,
-    },
+    votePeriod,
   };
 }
 

--- a/web/lib/stats.ts
+++ b/web/lib/stats.ts
@@ -1,5 +1,12 @@
 "use client";
 
+import {
+  getUtcVotePeriod,
+  type VotePeriod,
+} from "@/lib/vote-period";
+
+export type { VotePeriod } from "@/lib/vote-period";
+
 export type PetStats = {
   installs: number;
   likes: number;
@@ -18,12 +25,6 @@ export type CollectionStats = {
 
 export type VoteKind = "pet" | "collection";
 
-export type VotePeriod = {
-  id: string;
-  startsAt: number;
-  endsAt: number;
-};
-
 export type StatsPayload = {
   pets: StatsMap;
   collections: Record<string, CollectionStats>;
@@ -35,8 +36,15 @@ export type StatsPayload = {
 const STATS_SNAPSHOT_PATH = "/stats.json";
 const STATS_WRITE_API =
   process.env.NEXT_PUBLIC_STATS_WRITE_API ?? "https://api.codexpet.top";
-const LIKE_TIMEOUT_MS = 8_000;
+const STATS_WRITE_TIMEOUT_MS = 8_000;
 const STATS_CACHE_TTL_MS = 60_000;
+
+export class StatsWriteTimeoutError extends Error {
+  constructor(options?: ErrorOptions) {
+    super("The statistics write request timed out", options);
+    this.name = "StatsWriteTimeoutError";
+  }
+}
 
 let cachedStats: { payload: StatsPayload; expiresAt: number } | undefined;
 let pendingStats: Promise<StatsPayload> | undefined;
@@ -80,7 +88,7 @@ function normalizeStatsPayload(value: unknown): StatsPayload {
   }
   const rawPeriod = isRecord(value.votePeriod) ? value.votePeriod : {};
   const generatedAt = asNonNegativeNumber(value.generatedAt);
-  const fallbackStart = generatedAt;
+  const fallbackPeriod = getUtcVotePeriod(generatedAt || Date.now());
 
   return {
     pets,
@@ -91,11 +99,12 @@ function normalizeStatsPayload(value: unknown): StatsPayload {
       id:
         typeof rawPeriod.id === "string" && rawPeriod.id
           ? rawPeriod.id
-          : "current",
-      startsAt: asNonNegativeNumber(rawPeriod.startsAt) || fallbackStart,
+          : fallbackPeriod.id,
+      startsAt:
+        asNonNegativeNumber(rawPeriod.startsAt) || fallbackPeriod.startsAt,
       endsAt:
         asNonNegativeNumber(rawPeriod.endsAt) ||
-        fallbackStart + 7 * 24 * 60 * 60 * 1000,
+        fallbackPeriod.endsAt,
     },
   };
 }
@@ -183,7 +192,7 @@ export async function likePet(slug: string): Promise<LikeResult> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(
     () => controller.abort(),
-    LIKE_TIMEOUT_MS,
+    STATS_WRITE_TIMEOUT_MS,
   );
 
   try {
@@ -216,6 +225,11 @@ export async function likePet(slug: string): Promise<LikeResult> {
       logStatsError("Unable to persist anonymous like receipt", error);
     }
     return result;
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new StatsWriteTimeoutError({ cause: error });
+    }
+    throw error;
   } finally {
     window.clearTimeout(timeoutId);
   }
@@ -253,7 +267,7 @@ export async function voteForTarget(
   const controller = new AbortController();
   const timeoutId = window.setTimeout(
     () => controller.abort(),
-    LIKE_TIMEOUT_MS,
+    STATS_WRITE_TIMEOUT_MS,
   );
 
   try {
@@ -297,13 +311,21 @@ export async function voteForTarget(
 
     try {
       window.localStorage.setItem(
-        voteMarker(result.week || periodId, kind),
+        voteMarker(periodId, kind),
         slug,
       );
+      if (result.week !== periodId) {
+        window.localStorage.setItem(voteMarker(result.week, kind), slug);
+      }
     } catch (error: unknown) {
       logStatsError("Unable to persist anonymous weekly vote receipt", error);
     }
     return result;
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new StatsWriteTimeoutError({ cause: error });
+    }
+    throw error;
   } finally {
     window.clearTimeout(timeoutId);
   }

--- a/web/lib/vote-period.ts
+++ b/web/lib/vote-period.ts
@@ -16,3 +16,38 @@ export function getUtcVotePeriod(timestamp: number): VotePeriod {
     endsAt: startsAt + 7 * 24 * 60 * 60 * 1000,
   };
 }
+
+export function normalizeVotePeriod(
+  value: unknown,
+  fallbackTimestamp: number,
+): VotePeriod {
+  const fallback = getUtcVotePeriod(fallbackTimestamp);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return fallback;
+  }
+
+  const period = value as Record<string, unknown>;
+  const id = typeof period.id === "string" ? period.id : "";
+  const startsAt =
+    typeof period.startsAt === "number" &&
+    Number.isFinite(period.startsAt) &&
+    period.startsAt >= 0
+      ? period.startsAt
+      : -1;
+  const endsAt =
+    typeof period.endsAt === "number" &&
+    Number.isFinite(period.endsAt) &&
+    period.endsAt >= 0
+      ? period.endsAt
+      : -1;
+  const expected = startsAt >= 0 ? getUtcVotePeriod(startsAt) : null;
+  if (
+    expected &&
+    id === expected.id &&
+    startsAt === expected.startsAt &&
+    endsAt === expected.endsAt
+  ) {
+    return { id, startsAt, endsAt };
+  }
+  return fallback;
+}

--- a/web/lib/vote-period.ts
+++ b/web/lib/vote-period.ts
@@ -1,0 +1,18 @@
+export type VotePeriod = {
+  id: string;
+  startsAt: number;
+  endsAt: number;
+};
+
+export function getUtcVotePeriod(timestamp: number): VotePeriod {
+  const date = new Date(timestamp);
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - daysSinceMonday);
+  date.setUTCHours(0, 0, 0, 0);
+  const startsAt = date.getTime();
+  return {
+    id: date.toISOString().slice(0, 10),
+    startsAt,
+    endsAt: startsAt + 7 * 24 * 60 * 60 * 1000,
+  };
+}

--- a/web/scripts/prepare-site.mjs
+++ b/web/scripts/prepare-site.mjs
@@ -16,6 +16,7 @@ const repoRoot = join(webRoot, "..");
 const dataDir = join(webRoot, ".generated");
 const publicDir = join(webRoot, "public");
 const publicAssetsDir = join(publicDir, "assets");
+const authorSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const collectionCatalog = readJson("collections.json");
 const categoryCatalog = readJson("categories.json");
 const categoryByName = new Map(
@@ -90,6 +91,24 @@ function animatedPreviewForPet(slug, gifs, previewImage) {
   return gifs.idle ?? previewImage ?? `/assets/previews/${slug}/thumbnail.png`;
 }
 
+function resolveAuthorSlug(pet, submission) {
+  const declared =
+    typeof submission.author_slug === "string"
+      ? submission.author_slug.trim()
+      : "";
+  const fromPetSlug = pet.slug.split("--").slice(1).join("--");
+  const fromAuthor = String(submission.author ?? pet.author ?? "")
+    .normalize("NFKD")
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const authorSlug = declared || fromPetSlug || fromAuthor;
+  if (!authorSlugPattern.test(authorSlug)) {
+    throw new Error(`Unable to resolve a valid author slug for ${pet.slug}`);
+  }
+  return authorSlug;
+}
+
 const pets = readJson("pets.json").map((pet) => {
   const submission = readJson(`pets/${pet.slug}/submission.json`);
   const runtime = readJson(`pets/${pet.slug}/pet.json`);
@@ -103,8 +122,7 @@ const pets = readJson("pets.json").map((pet) => {
 
   return {
     ...pet,
-    author_slug:
-      submission.author_slug ?? pet.slug.split("--").slice(1).join("--"),
+    author_slug: resolveAuthorSlug(pet, submission),
     categoryLabel: categoryByName.get(pet.primary_category)?.label ?? {
       en: pet.primary_category,
       zh: pet.primary_category,

--- a/web/scripts/prepare-site.mjs
+++ b/web/scripts/prepare-site.mjs
@@ -99,7 +99,7 @@ function resolveAuthorSlug(pet, submission) {
   const fromPetSlug = pet.slug.split("--").slice(1).join("--");
   const fromAuthor = String(submission.author ?? pet.author ?? "")
     .normalize("NFKD")
-    .toLocaleLowerCase()
+    .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   const authorSlug = declared || fromPetSlug || fromAuthor;

--- a/worker/README.md
+++ b/worker/README.md
@@ -18,7 +18,7 @@ Cloudflare Worker that records privacy-conscious install, like, and weekly commu
 
 The API never stores raw IP addresses or client event IDs. Metric receipts are salted and hashed before short-lived deduplication. Likes store only a salted, pet-scoped IP hash so the same IP cannot like one pet twice and cannot be correlated across different pets.
 
-Weekly ballots use a salt-hashed identity scoped to the UTC week and target kind. A visitor can cast one pet vote and one collection vote per week, and can move either vote to another eligible target. Ballots expire automatically after thirteen weeks.
+Weekly ballots use a salt-hashed identity scoped to the UTC week and target kind. A visitor can cast one pet vote and one collection vote per week, and can move either vote to another eligible target. Vote writes are capped per source and hour to protect D1 from automated switching; ballots expire automatically after thirteen weeks.
 
 Normal page loads never invoke this Worker. Browsers read the deployment-time `/stats.json` snapshot from Cloudflare Pages as a free static asset, and pet detail views are not written to D1.
 

--- a/worker/migrations/0004_vote_rate_limits.sql
+++ b/worker/migrations/0004_vote_rate_limits.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS vote_rate_limits (
+  rate_key TEXT PRIMARY KEY,
+  target_kind TEXT NOT NULL CHECK (target_kind IN ('pet', 'collection')),
+  bucket_start INTEGER NOT NULL,
+  event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS vote_rate_limits_expires_idx
+  ON vote_rate_limits(expires_at);

--- a/worker/scripts/sync-catalog.mjs
+++ b/worker/scripts/sync-catalog.mjs
@@ -76,13 +76,26 @@ function buildSyncSql(catalog, collections, legacyStats) {
       );
     }
   }
-  const publicCollections = collections.filter(
+  const collectionSlugs = new Set();
+  const validCollections = [];
+  for (const collection of collections) {
+    if (
+      !collection ||
+      typeof collection.slug !== "string" ||
+      !collectionSlugPattern.test(collection.slug)
+    ) {
+      throw new Error(
+        `Invalid collection slug in catalog: ${JSON.stringify(collection?.slug)}`,
+      );
+    }
+    if (collectionSlugs.has(collection.slug)) continue;
+    collectionSlugs.add(collection.slug);
+    validCollections.push(collection);
+  }
+  const publicCollections = validCollections.filter(
     (collection) =>
-      collection &&
-      typeof collection.slug === "string" &&
-      collectionSlugPattern.test(collection.slug) &&
       (collectionCounts.get(collection.slug) ?? 0) >=
-        minimumPublicCollectionPets,
+      minimumPublicCollectionPets,
   );
   const voteTargets = [
     ...catalog.map((pet) => `('pet', ${sqlString(pet.slug)}, 1)`),

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -10,6 +10,7 @@ const COLLECTION_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const EVENT_ID_RE = /^[A-Za-z0-9._:-]{8,128}$/;
 const VOTE_KINDS = new Set(["pet", "collection"]);
 const INSTALL_RATE_LIMIT = 30;
+const VOTE_RATE_LIMIT = 60;
 const RECEIPT_TTL_MS = 8 * 24 * 60 * 60 * 1000;
 const VOTE_RETENTION_MS = 13 * 7 * 24 * 60 * 60 * 1000;
 const VOTE_CHANGE_COOLDOWN_MS = 2_000;
@@ -163,6 +164,22 @@ export async function buildVoteKey(request, env, kind, weekStart) {
   return sha256(
     `${env.HASH_SALT}|vote|${weekStart}|${kind}|${clientAddress(request)}`,
   );
+}
+
+export async function buildVoteRateKey(request, env, kind, timestamp) {
+  if (!env.HASH_SALT || env.HASH_SALT.length < 16) {
+    throw new HttpError(500, "metric hashing is not configured");
+  }
+  if (!VOTE_KINDS.has(kind)) {
+    throw new HttpError(400, "invalid vote kind");
+  }
+  const bucket = hourBucket(timestamp);
+  return {
+    key: await sha256(
+      `${env.HASH_SALT}|rate|vote|${kind}|${clientAddress(request)}|${bucket}`,
+    ),
+    bucket,
+  };
 }
 
 export function computeTrendingScore(installs7d, weeklyVotes = 0) {
@@ -359,6 +376,28 @@ async function trackVote(request, env, kind, slug) {
     throw new HttpError(403, "origin not allowed");
   }
 
+  const timestamp = Date.now();
+  const rate = await buildVoteRateKey(request, env, kind, timestamp);
+  const rateResult = await env.DB.prepare(
+    `INSERT INTO vote_rate_limits
+       (rate_key, target_kind, bucket_start, event_count, expires_at)
+     VALUES (?, ?, ?, 1, ?)
+     ON CONFLICT(rate_key) DO UPDATE SET
+       event_count = vote_rate_limits.event_count + 1,
+       expires_at = excluded.expires_at
+     RETURNING event_count`,
+  )
+    .bind(
+      rate.key,
+      kind,
+      rate.bucket,
+      timestamp + 2 * 60 * 60 * 1000,
+    )
+    .first();
+  if ((Number(rateResult?.event_count) || 0) > VOTE_RATE_LIMIT) {
+    throw new HttpError(429, "rate limit exceeded");
+  }
+
   const target = await env.DB.prepare(
     `SELECT slug
      FROM vote_targets
@@ -370,7 +409,6 @@ async function trackVote(request, env, kind, slug) {
     throw new HttpError(404, "vote target not found");
   }
 
-  const timestamp = Date.now();
   const period = votePeriod(timestamp);
   const visitorHash = await buildVoteKey(request, env, kind, period.id);
   const previous = await env.DB.prepare(
@@ -481,6 +519,9 @@ async function cleanupMetrics(env) {
       timestamp,
     ),
     env.DB.prepare("DELETE FROM weekly_votes WHERE expires_at < ?").bind(
+      timestamp,
+    ),
+    env.DB.prepare("DELETE FROM vote_rate_limits WHERE expires_at < ?").bind(
       timestamp,
     ),
   ]);

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -154,6 +154,24 @@ test("weekly vote keys allow one ballot per IP, kind, and week", async () => {
     "pet",
     Date.UTC(2026, 6, 13, 1),
   );
+  const sameRate = await buildVoteRateKey(
+    sameIpRequest,
+    env,
+    "pet",
+    Date.UTC(2026, 6, 13, 1, 59),
+  );
+  const otherIpRate = await buildVoteRateKey(
+    otherIpRequest,
+    env,
+    "pet",
+    Date.UTC(2026, 6, 13, 1),
+  );
+  const collectionRate = await buildVoteRateKey(
+    firstRequest,
+    env,
+    "collection",
+    Date.UTC(2026, 6, 13, 1),
+  );
   const nextHourRate = await buildVoteRateKey(
     firstRequest,
     env,
@@ -165,6 +183,9 @@ test("weekly vote keys allow one ballot per IP, kind, and week", async () => {
   assert.notEqual(first, otherIp);
   assert.notEqual(first, collectionBallot);
   assert.notEqual(first, nextWeek);
+  assert.equal(firstRate.key, sameRate.key);
+  assert.notEqual(firstRate.key, otherIpRate.key);
+  assert.notEqual(firstRate.key, collectionRate.key);
   assert.notEqual(firstRate.key, nextHourRate.key);
 });
 

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -5,6 +5,7 @@ import worker, {
   buildInstallKeys,
   buildLikeKey,
   buildVoteKey,
+  buildVoteRateKey,
   computeTrendingScore,
   isOriginAllowed,
   serializeStatsRows,
@@ -132,6 +133,9 @@ test("weekly vote keys allow one ballot per IP, kind, and week", async () => {
       "User-Agent": "another browser",
     },
   });
+  const otherIpRequest = new Request("https://stats.example/track/vote", {
+    headers: { "CF-Connecting-IP": "203.0.113.5" },
+  });
   const week = "2026-07-13";
 
   const first = await buildVoteKey(firstRequest, env, "pet", week);
@@ -143,10 +147,25 @@ test("weekly vote keys allow one ballot per IP, kind, and week", async () => {
     week,
   );
   const nextWeek = await buildVoteKey(firstRequest, env, "pet", "2026-07-20");
+  const otherIp = await buildVoteKey(otherIpRequest, env, "pet", week);
+  const firstRate = await buildVoteRateKey(
+    firstRequest,
+    env,
+    "pet",
+    Date.UTC(2026, 6, 13, 1),
+  );
+  const nextHourRate = await buildVoteRateKey(
+    firstRequest,
+    env,
+    "pet",
+    Date.UTC(2026, 6, 13, 2),
+  );
 
   assert.equal(first, sameBallot);
+  assert.notEqual(first, otherIp);
   assert.notEqual(first, collectionBallot);
   assert.notEqual(first, nextWeek);
+  assert.notEqual(firstRate.key, nextHourRate.key);
 });
 
 test("UTC vote periods start on Monday", () => {


### PR DESCRIPTION
## What changed

Follow-up hardening for #67 after automated review completed:

- rate-limit weekly vote writes per privacy-scoped source, kind, and hour with a dedicated D1 table
- escape dynamic JSON-LD values, normalize vote-period fallback keys, and harden author/collection slug handling
- add complete tab/tabpanel relationships plus arrow, Home, and End keyboard navigation
- cache build-time leaderboard work and send only the six compact community-pulse entries to the home client component
- localize the weekly install label and clarify that pet and collection ballots are separate

The home HTML dropped from 607,221 bytes to 350,020 bytes (42.4% smaller).

## Verification

- `npm run validate:pr` and root formatting check
- `npm test` in `worker/` (8 tests)
- `npx wrangler deploy --dry-run` in `worker/`
- isolated D1 migrations 0001-0004 and catalog sync
- isolated local Worker abuse test: first 60 hourly vote writes accepted, 61st returned HTTP 429
- `npm run lint` and full `npm run build` in `web/`
- 304 static pages, 298 indexable pages, complete 248.7 MiB bundle validation
- Playwright mobile keyboard/ARIA test: ArrowRight moved focus and selection to Contributors, panel label followed, horizontal overflow remained 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 社区脉搏展示专属的每周热门宠物与贡献者数据。
  * 排行榜支持键盘方向键、Home/End 导航，并优化无活动提示。
  * 新增“近 7 日安装”指标及相关中英文文案。
  * 投票新增按来源的每小时限流，过期记录会自动清理。

* **问题修复**
  * 改进作者与集合标识校验，避免重复或无效条目。
  * 增强结构化数据安全处理，降低脚本注入风险。
  * 优化投票周期及投票凭据记录的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->