### PR TITLE
Localize browser tab titles with the active language

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -78,7 +78,7 @@ npx wrangler pages deploy out --project-name=awesome-codex-pet
 
 - **Framework**: Next.js 15 with static export (`output: "export"`)
 - **Styling**: Tailwind CSS v4
-- **i18n**: Client-side locale detection (zh/en) with React Context
+- **i18n**: Client-side locale detection (zh/en) with React Context; visible browser-tab titles follow the active locale while static route metadata remains crawlable
 - **Data**: Generated at build time from `pets.json` + individual pet metadata
 - **Collection visibility**: Series and themes are published after they contain at least three pets
 - **Community pages**: Static contributor profiles and pet, contributor, and collection rankings are generated at build time

--- a/web/app/collections/[slug]/page.tsx
+++ b/web/app/collections/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { CollectionDetailContent } from "@/components/collection-detail-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import {
   getCollectionBySlug,
   getCollectionSlugs,
@@ -107,6 +108,10 @@ export default async function CollectionPage({
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en={`${collection.title.en} Codex pets`}
+        zh={`${collection.title.zh} Codex 宠物合集`}
+      />
       <CollectionDetailContent collection={collection} />
       <script
         type="application/ld+json"

--- a/web/app/collections/page.tsx
+++ b/web/app/collections/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { CollectionsPageContent } from "@/components/collections-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { getCollections } from "@/lib/collection-catalog";
 import { toCollectionCardData } from "@/lib/collections";
 import { getAllPets } from "@/lib/pets";
@@ -81,6 +82,10 @@ export default function CollectionsPage() {
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en="Codex pet series and themed collections"
+        zh="Codex 宠物系列与主题合集"
+      />
       <CollectionsPageContent collections={collectionCards} />
       <script
         type="application/ld+json"

--- a/web/app/contributors/[slug]/page.tsx
+++ b/web/app/contributors/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { ContributorPageContent } from "@/components/contributor-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import {
   getContributorBySlug,
   getContributorSlugs,
@@ -72,6 +73,10 @@ export default async function ContributorPage({
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en={`${contributor.name} Codex pets and community contributions`}
+        zh={`${contributor.name} 的 Codex 宠物与社区贡献`}
+      />
       <ContributorPageContent contributor={contributor} pets={pets} />
       <script
         dangerouslySetInnerHTML={{

--- a/web/app/guide/page.tsx
+++ b/web/app/guide/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { GuidePageContent } from "@/components/guide-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { getCategoryCatalog } from "@/lib/categories";
 import { withSiteKeywords } from "@/lib/seo-keywords";
 import { siteConfig } from "@/lib/site";
@@ -78,6 +79,10 @@ export default function GuidePage() {
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en="Craft and submit a selected Codex pet"
+        zh="制作与投稿 Codex 宠物"
+      />
       <GuidePageContent categories={categories} />
       <script
         type="application/ld+json"

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { InstallPageContent } from "@/components/install-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { withSiteKeywords } from "@/lib/seo-keywords";
 import { siteConfig } from "@/lib/site";
 
@@ -140,6 +141,10 @@ export default function InstallPage() {
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en="Install a Codex pet in seconds"
+        zh="快速安装 Codex 宠物"
+      />
       <InstallPageContent />
       <script
         type="application/ld+json"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { FeaturedCollections } from "@/components/featured-collections";
 import { HeroSection } from "@/components/hero-section";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { PetGallery } from "@/components/pet-gallery";
 import { CommunityPulse } from "@/components/community-pulse";
 import { getCollections } from "@/lib/collection-catalog";
@@ -141,6 +142,10 @@ export default function HomePage() {
 
   return (
     <main>
+      <LocalizedDocumentTitle
+        en="Free Codex pet gallery and community"
+        zh="Codex 宠物画廊与社区"
+      />
       <HeroSection
         petCount={pets.length}
         categoryCount={categories.length}

--- a/web/app/pets/[slug]/page.tsx
+++ b/web/app/pets/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { PetDetailContent } from "@/components/pet-detail-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { getActionEntries, getAllPets, getPetBySlug } from "@/lib/pets";
 import { getPetSeoKeywords } from "@/lib/seo-keywords";
 import { siteConfig } from "@/lib/site";
@@ -139,6 +140,12 @@ export default async function PetDetailPage({
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en={`${pet.localizedNames.en ?? pet.name} Codex pet by ${
+          pet.author_handle ?? pet.author
+        }`}
+        zh={`${pet.localizedNames.zh ?? pet.name} Codex 宠物`}
+      />
       <PetDetailContent
         pet={pet}
         actions={actions}

--- a/web/app/rankings/page.tsx
+++ b/web/app/rankings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { RankingsPageContent } from "@/components/rankings-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { getLeaderboardData } from "@/lib/leaderboards";
 import { getAllPets } from "@/lib/pets";
 import { withSiteKeywords } from "@/lib/seo-keywords";
@@ -93,6 +94,10 @@ export default function RankingsPage() {
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en="Codex pet rankings"
+        zh="Codex 宠物排行榜"
+      />
       <RankingsPageContent data={data} />
       <script
         dangerouslySetInnerHTML={{

--- a/web/app/request/page.tsx
+++ b/web/app/request/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { RequestPageContent } from "@/components/request-page-content";
+import { LocalizedDocumentTitle } from "@/components/localized-document-title";
 import { getAllPets } from "@/lib/pets";
 import { withSiteKeywords } from "@/lib/seo-keywords";
 import { siteConfig } from "@/lib/site";
@@ -129,6 +130,10 @@ export default function RequestPage() {
 
   return (
     <>
+      <LocalizedDocumentTitle
+        en="Request a Codex pet for free"
+        zh="免费申请 Codex 宠物"
+      />
       <RequestPageContent locale="en" petCount={pets.length} />
       <script
         type="application/ld+json"

--- a/web/components/localized-document-title.tsx
+++ b/web/components/localized-document-title.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useLocale } from "@/components/locale-provider";
+import { siteConfig } from "@/lib/site";
+
+type LocalizedDocumentTitleProps = {
+  en: string;
+  zh: string;
+};
+
+export function LocalizedDocumentTitle({
+  en,
+  zh,
+}: LocalizedDocumentTitleProps) {
+  const { locale } = useLocale();
+
+  useEffect(() => {
+    const localizedTitle = `${locale === "zh" ? zh : en} · ${siteConfig.title}`;
+    const applyTitle = () => {
+      if (document.title !== localizedTitle) {
+        document.title = localizedTitle;
+      }
+    };
+
+    applyTitle();
+
+    // Next may stream route metadata after hydration, so keep the visible tab
+    // title aligned with the active client-side locale.
+    const observer = new MutationObserver(applyTitle);
+    observer.observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, [en, locale, zh]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- make visible browser-tab titles follow the active English or Chinese site language
- cover the gallery, collections, rankings, install, guide, request, contributor, and pet detail routes
- use localized pet and collection names for dynamic page titles
- preserve server-rendered metadata for crawlers and SEO
- keep client-side titles stable when Next.js streams route metadata after hydration

## Validation

- `npm run validate:pr`
- web `npm run lint`
- web `npm run build`
- 298 indexable pages passed SEO validation
- local browser verification: homepage switched between English and Chinese titles
- local browser verification: SalaryCat displayed `月薪喵 Codex 宠物 · Awesome Codex Pet`
- pet tag labels remained localized: 动物、猫咪、开源、月薪喵、V2
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增中英文页面标题本地化，覆盖首页、宠物详情、合集、贡献者、指南、安装、排行榜和请求页面。
  * 浏览器标签页标题会随当前语言和页面内容自动更新。
  * 保留静态路由元数据，确保搜索引擎仍可抓取页面信息。

* **文档**
  * 更新架构说明，补充语言检测与本地化标题行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->