### PR TITLE
Animate pet previews across community rankings

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -85,7 +85,7 @@ npx wrangler pages deploy out --project-name=awesome-codex-pet
 - **Hosting**: Cloudflare Pages (global CDN, free tier)
 - **Stats reads**: deployment-time `public/stats.json`, served as a free Pages static asset; rankings do not poll the Worker
 - **Stats writes**: a separate Worker at `https://api.codexpet.top` records explicit installs, IP-limited likes, and one pet vote plus one collection vote per privacy-scoped visitor each week. Ordinary page views never invoke it. See `worker/README.md`.
-- **Preview delivery**: cards load a static thumbnail first and fetch animation on hover or keyboard focus; detail pages keep the complete action set
+- **Preview delivery**: cards load a static thumbnail first and fetch animation on hover or keyboard focus; the top three pet rankings animate automatically while lower pet rows and contributor/collection mosaics animate on interaction; detail pages keep the complete action set
 - **Caching**: Next.js hashed assets are immutable, preview assets use a seven-day browser cache, and the deployment-time statistics snapshot uses a ten-minute cache
 
 ## Environment variables

--- a/web/components/rankings-page-content.tsx
+++ b/web/components/rankings-page-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import {
   type KeyboardEvent,
+  type PointerEvent,
   useEffect,
   useMemo,
   useState,
@@ -81,6 +82,7 @@ function PreviewMosaic({
   locale: "en" | "zh";
   pets: GalleryPet[];
 }) {
+  const [isAnimating, setIsAnimating] = useState(false);
   const visiblePets = pets.slice(0, 3);
   const layoutClass =
     visiblePets.length === 1
@@ -94,6 +96,25 @@ function PreviewMosaic({
       aria-label={label}
       className={`grid h-16 w-24 shrink-0 overflow-hidden rounded-md border border-border bg-bg-secondary sm:h-20 sm:w-32 ${layoutClass}`}
       href={href}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setIsAnimating(false);
+        }
+      }}
+      onFocus={() => {
+        if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          setIsAnimating(true);
+        }
+      }}
+      onPointerEnter={(event) => {
+        if (
+          event.pointerType !== "touch" &&
+          !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ) {
+          setIsAnimating(true);
+        }
+      }}
+      onPointerLeave={() => setIsAnimating(false)}
     >
       {visiblePets.map((pet, index) => (
         <span
@@ -109,10 +130,57 @@ function PreviewMosaic({
           <img
             alt={getLocalizedPetName(pet, locale)}
             className="max-h-full max-w-full object-contain [image-rendering:pixelated]"
-            src={pet.previewImage}
+            decoding="async"
+            loading="lazy"
+            src={
+              isAnimating ? pet.animatedPreviewImage : pet.previewImage
+            }
           />
         </span>
       ))}
+    </Link>
+  );
+}
+
+function PetRankingPreview({
+  autoAnimate,
+  name,
+  pet,
+}: {
+  autoAnimate: boolean;
+  name: string;
+  pet: GalleryPet;
+}) {
+  const [isInteracting, setIsInteracting] = useState(false);
+  const isAnimating = autoAnimate || isInteracting;
+
+  function startAnimation(event?: PointerEvent<HTMLAnchorElement>) {
+    if (
+      event?.pointerType === "touch" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+    setIsInteracting(true);
+  }
+
+  return (
+    <Link
+      aria-label={name}
+      className="flex size-16 items-center justify-center overflow-hidden rounded-md border border-border bg-bg-secondary sm:size-20"
+      href={`/pets/${pet.slug}`}
+      onBlur={() => setIsInteracting(false)}
+      onFocus={() => startAnimation()}
+      onPointerEnter={startAnimation}
+      onPointerLeave={() => setIsInteracting(false)}
+    >
+      <img
+        alt={name}
+        className="max-h-full max-w-full object-contain [image-rendering:pixelated]"
+        decoding="async"
+        loading="lazy"
+        src={isAnimating ? pet.animatedPreviewImage : pet.previewImage}
+      />
     </Link>
   );
 }
@@ -178,6 +246,7 @@ export function RankingsPageContent({
   });
   const [pendingVote, setPendingVote] = useState<string | null>(null);
   const [voteError, setVoteError] = useState(false);
+  const [motionAllowed, setMotionAllowed] = useState(false);
   const [petVotes, setPetVotes] = useState(() =>
     Object.fromEntries(
       data.pets.map((entry) => [entry.pet.slug, entry.stats.weeklyVotes]),
@@ -198,6 +267,14 @@ export function RankingsPageContent({
       collection: getWeeklyVote(data.votePeriod.id, "collection"),
     });
   }, [data.votePeriod.id]);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updateMotionPreference = () => setMotionAllowed(!media.matches);
+    updateMotionPreference();
+    media.addEventListener("change", updateMotionPreference);
+    return () => media.removeEventListener("change", updateMotionPreference);
+  }, []);
 
   const rankedPets = useMemo(
     () => sortRanked(data.pets, rankingWindow).slice(0, rankingLimit),
@@ -389,6 +466,7 @@ export function RankingsPageContent({
           <PetRanking
             entries={rankedPets}
             locale={locale}
+            motionAllowed={motionAllowed}
             pendingVote={pendingVote}
             selectedVote={selectedVotes.pet}
             showVote={rankingWindow === "weekly"}
@@ -444,6 +522,7 @@ export function RankingsPageContent({
 function PetRanking({
   entries,
   locale,
+  motionAllowed,
   pendingVote,
   selectedVote,
   showVote,
@@ -452,6 +531,7 @@ function PetRanking({
 }: {
   entries: RankedPet[];
   locale: "en" | "zh";
+  motionAllowed: boolean;
   pendingVote: string | null;
   selectedVote: string | null;
   showVote: boolean;
@@ -474,17 +554,11 @@ function PetRanking({
             >
               {rank}
             </span>
-            <Link
-              aria-label={name}
-              className="flex size-16 items-center justify-center overflow-hidden rounded-md border border-border bg-bg-secondary sm:size-20"
-              href={`/pets/${entry.pet.slug}`}
-            >
-              <img
-                alt={name}
-                className="max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                src={entry.pet.previewImage}
-              />
-            </Link>
+            <PetRankingPreview
+              autoAnimate={motionAllowed && rank <= 3}
+              name={name}
+              pet={entry.pet}
+            />
             <div className="min-w-0">
               <Link
                 className="block truncate text-sm font-semibold text-text hover:text-accent sm:text-base"

--- a/web/components/rankings-page-content.tsx
+++ b/web/components/rankings-page-content.tsx
@@ -75,11 +75,13 @@ function PreviewMosaic({
   href,
   label,
   locale,
+  motionAllowed,
   pets,
 }: {
   href: string;
   label: string;
   locale: "en" | "zh";
+  motionAllowed: boolean;
   pets: GalleryPet[];
 }) {
   const [isAnimating, setIsAnimating] = useState(false);
@@ -102,15 +104,12 @@ function PreviewMosaic({
         }
       }}
       onFocus={() => {
-        if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        if (motionAllowed) {
           setIsAnimating(true);
         }
       }}
       onPointerEnter={(event) => {
-        if (
-          event.pointerType !== "touch" &&
-          !window.matchMedia("(prefers-reduced-motion: reduce)").matches
-        ) {
+        if (event.pointerType !== "touch" && motionAllowed) {
           setIsAnimating(true);
         }
       }}
@@ -133,7 +132,9 @@ function PreviewMosaic({
             decoding="async"
             loading="lazy"
             src={
-              isAnimating ? pet.animatedPreviewImage : pet.previewImage
+              motionAllowed && isAnimating
+                ? pet.animatedPreviewImage
+                : pet.previewImage
             }
           />
         </span>
@@ -144,21 +145,20 @@ function PreviewMosaic({
 
 function PetRankingPreview({
   autoAnimate,
+  motionAllowed,
   name,
   pet,
 }: {
   autoAnimate: boolean;
+  motionAllowed: boolean;
   name: string;
   pet: GalleryPet;
 }) {
   const [isInteracting, setIsInteracting] = useState(false);
-  const isAnimating = autoAnimate || isInteracting;
+  const isAnimating = motionAllowed && (autoAnimate || isInteracting);
 
   function startAnimation(event?: PointerEvent<HTMLAnchorElement>) {
-    if (
-      event?.pointerType === "touch" ||
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    ) {
+    if (event?.pointerType === "touch" || !motionAllowed) {
       return;
     }
     setIsInteracting(true);
@@ -485,6 +485,7 @@ export function RankingsPageContent({
         {tab === "contributors" ? (
           <ContributorRanking
             entries={rankedContributors}
+            motionAllowed={motionAllowed}
             rankingWindow={rankingWindow}
           />
         ) : null}
@@ -500,6 +501,7 @@ export function RankingsPageContent({
           <CollectionRanking
             entries={rankedCollections}
             locale={locale}
+            motionAllowed={motionAllowed}
             pendingVote={pendingVote}
             selectedVote={selectedVotes.collection}
             showVote={rankingWindow === "weekly"}
@@ -555,7 +557,8 @@ function PetRanking({
               {rank}
             </span>
             <PetRankingPreview
-              autoAnimate={motionAllowed && rank <= 3}
+              autoAnimate={rank <= 3}
+              motionAllowed={motionAllowed}
               name={name}
               pet={entry.pet}
             />
@@ -611,9 +614,11 @@ function PetRanking({
 
 function ContributorRanking({
   entries,
+  motionAllowed,
   rankingWindow,
 }: {
   entries: RankedContributor[];
+  motionAllowed: boolean;
   rankingWindow: RankingWindow;
 }) {
   const { locale, t } = useLocale();
@@ -635,6 +640,7 @@ function ContributorRanking({
               href={`/contributors/${entry.slug}`}
               label={entry.name}
               locale={locale}
+              motionAllowed={motionAllowed}
               pets={entry.pets}
             />
             <div className="min-w-0">
@@ -685,6 +691,7 @@ function ContributorRanking({
 function CollectionRanking({
   entries,
   locale,
+  motionAllowed,
   pendingVote,
   selectedVote,
   showVote,
@@ -693,6 +700,7 @@ function CollectionRanking({
 }: {
   entries: RankedCollection[];
   locale: "en" | "zh";
+  motionAllowed: boolean;
   pendingVote: string | null;
   selectedVote: string | null;
   showVote: boolean;
@@ -719,6 +727,7 @@ function CollectionRanking({
               href={`/collections/${collection.slug}`}
               label={collection.title[locale]}
               locale={locale}
+              motionAllowed={motionAllowed}
               pets={collection.coverPets}
             />
             <div className="min-w-0">


### PR DESCRIPTION
## Summary

- autoplay animated idle previews for the top three pets in the active leaderboard
- animate lower-ranked pets on pointer hover or keyboard focus
- animate contributor and collection preview mosaics on interaction
- keep static thumbnails as the default so only three extra animations load on page entry
- respect the operating system's reduced-motion preference

## Validation

- `npm run validate:pr`
- web `npm run lint`
- web `npm run build`
- 298 indexable pages passed SEO validation
- bundle check passed at 250.1 MiB
- local browser verification confirmed ranks 1-3 use animated idle WebP previews while ranks 4+ retain static thumbnails until interaction
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 排行榜预览支持动画效果：前三名可自动播放，其余内容在聚焦、悬停或触摸时播放。
  * 支持遵循系统“减少动态效果”设置，动态调整动画行为。
  * 优化预览图片加载，提升页面性能与浏览体验。

* **文档**
  * 更新架构说明，补充预览动画的触发方式与适用范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->