### PR TITLE
fix(cli): validate pet IDs before resolving paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "readmes": "node scripts/generate-readmes.mjs",
     "star-history": "node scripts/generate-star-history.mjs",
     "test:duplicates": "node --test scripts/test/pet-duplicates.test.mjs",
+    "test:install": "node --test scripts/test/install-pet.test.mjs",
     "validate": "node scripts/validate-pets.mjs --require-generated-assets",
-    "validate:pr": "npm run test:duplicates && node scripts/validate-pets.mjs"
+    "validate:pr": "npm run test:duplicates && npm run test:install && node scripts/validate-pets.mjs"
   },
   "devDependencies": {
     "prettier": "^3.5.3"

--- a/scripts/install-pet.mjs
+++ b/scripts/install-pet.mjs
@@ -78,14 +78,22 @@ if (codexHomeIndex !== -1) {
 }
 
 const petSlug = args[0];
-const petDir = join(petsDir, petSlug);
-const petJsonPath = join(petDir, "pet.json");
-const spritesheetPath = join(petDir, "spritesheet.webp");
 
 if (!petSlug) {
   usage();
   process.exit(1);
 }
+
+if (!/^[a-z0-9]+(?:-[a-z0-9]+)*--[a-z0-9]+(?:-[a-z0-9]+)*$/.test(petSlug)) {
+  console.error(
+    `Invalid pet id: ${petSlug}. Expected format: pet-slug--author-slug`,
+  );
+  process.exit(1);
+}
+
+const petDir = join(petsDir, petSlug);
+const petJsonPath = join(petDir, "pet.json");
+const spritesheetPath = join(petDir, "spritesheet.webp");
 
 if (!existsSync(petDir)) {
   console.error(`Pet not found: ${petSlug}`);

--- a/scripts/test/install-pet.test.mjs
+++ b/scripts/test/install-pet.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const installerPath = fileURLToPath(
+  new URL("../install-pet.mjs", import.meta.url),
+);
+
+test("rejects pet IDs that escape the catalog directory", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "awesome-codex-pet-"));
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        installerPath,
+        "../pets/firefly--lingxiaotian",
+        "--codex-home",
+        codexHome,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, AWESOME_CODEX_PET_NO_STATS: "1" },
+      },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Invalid pet id:/);
+  } finally {
+    rmSync(codexHome, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Validate pet IDs before resolving filesystem paths in the installer.
- Add a regression test for path traversal input.
- Include the installer regression test in `validate:pr`.

## Root cause

The installer joined the user-provided pet ID to the catalog path before validating it, allowing path traversal input to escape the catalog directory.

## Validation

- `npm run test:duplicates`
- `npm run test:install`
- `node --check scripts/install-pet.mjs`
- `node --check scripts/test/install-pet.test.mjs`
- `node scripts/check-readme-locales.mjs`
- `npx --yes -p prettier@3.5.3 prettier --check package.json scripts/test/install-pet.test.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新增功能**
  * 新增安装流程测试，覆盖无效宠物标识的处理。
  * 安装时校验宠物标识格式，仅接受小写字母、数字和连字符。

* **错误修复**
  * 无效宠物标识现在会明确提示错误并安全终止，避免访问异常路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->