### PR TITLE
Fix Chud Codex spritesheet hash

### DIFF
--- a/pets/chud-codex--jorge-cuevas90003/submission.json
+++ b/pets/chud-codex--jorge-cuevas90003/submission.json
@@ -28,5 +28,5 @@
     "pet_json": "pet.json",
     "spritesheet": "spritesheet.webp"
   },
-  "spritesheet_sha256": "95736a67b7a787ba82c9e4b15a0a4d482e7f138d07cd0cee178d4f0b40a6d50f"
+  "spritesheet_sha256": "e1211e3317065e70ef342f97fcc37337036c1e41ab2818db5c8c378c976dfc79"
 }


### PR DESCRIPTION
## Summary
- update the Chud Codex submission metadata to match the rebuilt spritesheet
- restore local package installation, which verifies `submission.json.spritesheet_sha256`

## Root cause
The atlas was rebuilt in PR #113, but its metadata retained the previous spritesheet hash.

## Validation
- `npm run lint`
- `npm run validate:pr`
- local install of `chud-codex--jorge-cuevas90003` with `--no-stats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 更新精灵图文件的校验值，确保资源完整性验证能够正常进行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->