### PR TITLE
fix: remove invalid game characters collection

### DIFF
--- a/pets/om-nom--kasyan1337/submission.json
+++ b/pets/om-nom--kasyan1337/submission.json
@@ -8,7 +8,6 @@
   "author_url": "https://github.com/kasyan1337",
   "primary_category": "Game Characters",
   "tags": ["game-character", "cut-the-rope", "om-nom", "fan-art", "lime-green"],
-  "collections": ["game-characters"],
   "source_type": "fan-art",
   "source_url": "https://github.com/kasyan1337/om-nom-codex-pet",
   "license": "Unofficial fan content; non-commercial use only",


### PR DESCRIPTION
## 修复内容

移除 `om-nom--kasyan1337` 中不存在的 `game-characters` collection 引用。

该宠物仍保留 `Game Characters` 主分类；该分类不依赖 collection 定义。

## 原因

`collections.json` 未定义 `game-characters`，导致 `validate-pets.mjs` 失败，并阻塞无关的宠物 PR。

## 验证

- JSON 格式检查通过
- `pet-duplicates` 测试通过
- `request-linking` 测试通过
- diff 仅删除一条无效 collection 引用


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **更新**
  * 移除了宠物元数据中的“游戏角色”集合标记。
  * 其余宠物信息保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->