### PR TITLE
Add stitch pet

### DIFF
--- a/pets/stitch--wt521lcl/pet.json
+++ b/pets/stitch--wt521lcl/pet.json
@@ -1,0 +1,19 @@
+{
+  "id": "stitch--wt521lcl",
+  "name": "Stitch",
+  "description": "A fan-art Codex pet based on Disney's Stitch (Experiment 626) from Lilo & Stitch.",
+  "spritesheetPath": "spritesheet.webp",
+  "spriteVersionNumber": 2,
+  "localized_names": {
+    "en": "Stitch",
+    "zh": "史迪奇"
+  },
+  "author": "星辰浩瀚",
+  "author_handle": "wt521lcl",
+  "author_url": "https://github.com/wt521lcl",
+  "primary_category": "Animation Characters",
+  "canonical_key": "disney/lilo-and-stitch/stitch",
+  "license": "Non-commercial use only. Fan art based on Disney's Stitch from Lilo & Stitch.",
+  "collections": [],
+  "tags": ["disney", "lilo-and-stitch", "alien", "experiment-626", "fan-art"]
+}

--- a/pets/stitch--wt521lcl/spritesheet.webp
+++ b/pets/stitch--wt521lcl/spritesheet.webp
@@ -1,0 +1,1 @@
+D:\python\chatgpt\codx\temp-pet-creation\pets\stitch--wt521lcl\spritesheet.webp

--- a/pets/stitch--wt521lcl/submission.json
+++ b/pets/stitch--wt521lcl/submission.json
@@ -1,0 +1,19 @@
+{
+  "name": "Stitch",
+  "canonical_key": "disney/lilo-and-stitch/stitch",
+  "author": "星辰浩瀚",
+  "author_handle": "wt521lcl",
+  "author_url": "https://github.com/wt521lcl",
+  "primary_category": "Animation Characters",
+  "collections": [],
+  "license": "Non-commercial use only. Fan art based on Disney's Stitch from Lilo & Stitch.",
+  "description": "A fan-art Codex pet based on Disney's Stitch (Experiment 626) from Lilo & Stitch, featuring the iconic blue alien with large ears and playful expression.",
+  "localized_names": {
+    "en": "Stitch",
+    "zh": "史迪奇"
+  },
+  "spriteVersionNumber": 2,
+  "source_url": "",
+  "source_type": "AI-generated fan art based on publicly available character references",
+  "non_commercial": true
+}


### PR DESCRIPTION
## Summary

- What pet are you adding or updating?
- What category does it belong to?
- Related request or submission issue (if any; use `Closes #123` for a completed request):

Submit a completed pet as **Ready for review**, not as a draft. Use a draft only for knowingly unfinished work, and list what remains.

## Visual evidence

Drag a contact sheet here. CI also uploads a downloadable preview artifact for changed pets. Preview files belong in the PR description or CI artifact, not in the pet directory.

## Checklist

- [ ] This pull request focuses on one pet only
- [ ] I checked the gallery and open issues for the same character or concept
- [ ] If this pet fulfills a request, I commented on that Issue and linked it with `Closes #<number>`
- [ ] `canonical_key` groups the character correctly; if that key already exists, `variant_note` explains this independent version
- [ ] This spritesheet is independently produced and is not a byte-identical copy of another package
- [ ] Folder name uses `pet-slug--author-slug`
- [ ] Pet folder contains only `submission.json`, `pet.json`, and `spritesheet.webp`
- [ ] `pet.json` `id` matches the folder name
- [ ] v1 uses a `1536x1872` atlas and omits `spriteVersionNumber` or sets it to `1`
- [ ] v2 uses a `1536x2288` atlas and sets `spriteVersionNumber: 2`
- [ ] v2 includes and visually reviews all 16 look directions
- [ ] `submission.json` is filled in
- [ ] Authorship is clear
- [ ] Asset usage terms are clear: either a formal license or an explicit non-commercial-only statement
- [ ] A contact sheet or equivalent frame-by-frame visual preview is available to reviewers
- [ ] Character identity, scale, baseline, and props remain consistent across every frame
- [ ] Right/left directions, running gait, action meanings, and v2 look directions are visually correct
- [ ] Transparent edges were checked on checkerboard, dark, and light backgrounds
- [ ] I understand maintainers will visually review character direction, action quality, animation continuity, and transparent-edge colors, and may optimize the spritesheet or metadata before merge
- [ ] Generated previews, README files, `pets.json`, prompts, references, QA media, and Hatch Pet run directories are not included
- [ ] `npm run validate:pr` passes
- [ ] `npm run lint` passes
- [ ] No unrelated files are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增粉丝艺术宠物“史迪奇（Stitch）”。
  * 提供中英文名称、描述、作者、分类、许可和非商业用途信息。
  * 添加对应的精灵图集资源，支持宠物在应用中展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->